### PR TITLE
Added basic NPM packaging

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,19 @@
+/*
+ * Export all the modules at once by attaching them to the 'exports' of this
+ * file.
+ *
+ * Thusly:
+ *
+ * var rrd = require('javascript-rrd');
+ * rrd.binaryFile.FetchBinaryURLAsync(FILENAME, function (b) {
+ *      ...
+ * });
+ *
+ */
+exports.binaryFile = require('./binaryFile');
+exports.rrdFile = require('./rrdFile');
+exports.rrdFilter = require('./rrdFilter');
+exports.rrdFlot = require('./rrdFlot');
+exports.rrdFlotMatrix = require('./rrdFlotMatrix');
+exports.rrdFlotSupport = require('./rrdFlotSupport');
+exports.rrdMultiFile = require('./rrdMultiFile');

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
         "node": "*"
     },
     "directories": {
-        "lib": "./lib"
+        "lib": "./lib",
+        "example": "./examples"
     },
     "main": "./lib/index.js"
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+    "author": {
+        "name": "Timothy J. Fontaine",
+        "email": "tjfontaine@gmail.com",
+        "url": "http://www.atxconsulting.com"
+    },
+    "license": "MIT/X11",
+    "name": "javascript-rrd",
+    "description": "Native RRDtool database interface",
+    "version": "0.0.0",
+    "homepage": "http://sourceforge.net/projects/javascriptrrd/",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/msiebuhr/javascript-rrd.git"
+    },
+    "engines": {
+        "node": "*"
+    },
+    "directories": {
+        "lib": "./lib"
+    },
+    "main": "./lib/index.js"
+}


### PR DESCRIPTION
It should now work with NPM; either using `npm link` in a local checkout, or using `npm install javascript-rrd` (if you/someone else add it to NPM).

It also adds a `index.js`-file, as importing works better if there's no ambiguity about what to import...
